### PR TITLE
since gfw clone golang.org/* for gobuildweb

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -13,6 +13,8 @@ go get github.com/mijia/sweb/log
 cd /lain/app
 
 yum -y install unzip
+git clone --depth=1 https://github.com/golang/sys.git /go/src/golang.org/x/sys # GFW
+git clone --depth=1 https://github.com/golang/net.git /go/src/golang.org/x/net
 go get github.com/mijia/gobuildweb
 gobuildweb dist
 ls -1 | grep -v node_modules | xargs rm -rf


### PR DESCRIPTION
gobuildweb 依赖 golang.org 的包，所以在装 gobuildweb 之前从 github 上下载好。
