### PR TITLE
Disable debug mode

### DIFF
--- a/lvault.sh
+++ b/lvault.sh
@@ -2,7 +2,7 @@
 
 sleep 3
 environ=$LAIN_DOMAIN
-DEBUG="true"
+DEBUG="false"
 HTTPS="false"
 
 source ./config


### PR DESCRIPTION
1. 禁用 debug mode，因为缺少并发支持。

这是洪教授找的问题: 线上的 lvault 在使用 sweb 时，使用了 IsDevelopment = true 的 option ，而这个 option 是为了简化开发用的，并没有并发支持。
